### PR TITLE
Suggestion: An alias method to output readonly array for Seq

### DIFF
--- a/packages/leseq/src/operators/async/chunkAsync.ts
+++ b/packages/leseq/src/operators/async/chunkAsync.ts
@@ -15,8 +15,8 @@ import { AsyncGen, AsyncOperator, AsyncSeq } from '../../asyncSeq';
  * @typeParam T Source element type.
  * @category Async Operators
  */
-export const chunkAsync = <T>(size: number): AsyncOperator<T, T[]> =>
-  async function* chunkAsync(source: AsyncSeq<T>): AsyncGen<T[]> {
+export const chunkAsync = <T>(size: number): AsyncOperator<T, readonly T[]> =>
+  async function* chunkAsync(source: AsyncSeq<T>): AsyncGen<readonly T[]> {
     let ch: T[] = [];
     for await (const one of source) {
       ch.push(one);

--- a/packages/leseq/src/operators/async/groupByAsync.ts
+++ b/packages/leseq/src/operators/async/groupByAsync.ts
@@ -77,8 +77,8 @@ export const groupByAsync = <T, TComparableValue, TKey = T, TValue = T>(
   keySelector: (target: T) => Promise<TKey>,
   elementSelector: (target: T) => Promise<TValue> = asyncDefaultSelector,
   comparableValueForKey?: (key: TKey) => Promise<TComparableValue>
-): AsyncOperator<T, { key: TKey; values: TValue[] }> =>
-  async function* groupByAsync(source: AsyncSeq<T>): AsyncGen<{ key: TKey; values: TValue[] }> {
+): AsyncOperator<T, { key: TKey; values: readonly TValue[] }> =>
+  async function* groupByAsync(source: AsyncSeq<T>): AsyncGen<{ key: TKey; values: readonly TValue[] }> {
     const resultMap = new Map<TComparableValue | TKey, { key: TKey; values: TValue[] }>();
     const createKeyValue = async (i: T) => (comparableValueForKey ? comparableValueForKey(await keySelector(i)) : keySelector(i));
 

--- a/packages/leseq/src/operators/chunk.ts
+++ b/packages/leseq/src/operators/chunk.ts
@@ -13,8 +13,8 @@ import { Gen, Operator, Seq } from '../seq';
  * @typeParam T Source element type.
  * @category Operators
  */
-export const chunk = <T>(size: number): Operator<T, T[]> =>
-  function* chunk(source: Seq<T>): Gen<T[]> {
+export const chunk = <T>(size: number): Operator<T, readonly T[]> =>
+  function* chunk(source: Seq<T>): Gen<readonly T[]> {
     let ch: T[] = [];
     for (const one of source) {
       ch.push(one);

--- a/packages/leseq/src/operators/groupBy.ts
+++ b/packages/leseq/src/operators/groupBy.ts
@@ -70,8 +70,8 @@ export const groupBy = <T, TComparableValue, TKey = T, TValue = T>(
   keySelector: (target: T) => TKey,
   elementSelector: (target: T) => TValue = defaultSelector,
   comparableValueForKey?: (key: TKey) => TComparableValue
-): Operator<T, { key: TKey; values: TValue[] }> =>
-  function* groupBy(source: Seq<T>): Gen<{ key: TKey; values: TValue[] }> {
+): Operator<T, { key: TKey; values: readonly TValue[] }> =>
+  function* groupBy(source: Seq<T>): Gen<{ key: TKey; values: readonly TValue[] }> {
     const resultMap = new Map<TComparableValue | TKey, { key: TKey; values: TValue[] }>();
     const createKeyValue = (i: T) => (comparableValueForKey ? comparableValueForKey(keySelector(i)) : keySelector(i));
     for (const one of source) {

--- a/packages/leseq/src/operators/orderBy.ts
+++ b/packages/leseq/src/operators/orderBy.ts
@@ -50,7 +50,7 @@ export const orderBy = <T, TKey>(
   compareFunction: (a: TKey, b: TKey) => number = defaultCompareFunction
 ): Operator<T> =>
   function* orderBy(source: Seq<T>): Gen<T> {
-    const sortedArray = source.toArray().sort(createSortFunction(keySelector, sortType, compareFunction));
+    const sortedArray = source.toMutableArray().sort(createSortFunction(keySelector, sortType, compareFunction));
     yield* sortedArray;
   };
 

--- a/packages/leseq/src/seq.ts
+++ b/packages/leseq/src/seq.ts
@@ -92,6 +92,10 @@ export class Seq<T> implements Iterable<T> {
   toArray(): T[] {
     return [...this];
   }
+
+  toReadonlyArray(): readonly T[] {
+    return [...this];
+  }
 }
 
 class PipelineSeq<T> extends Seq<T> {

--- a/packages/leseq/src/seq.ts
+++ b/packages/leseq/src/seq.ts
@@ -89,11 +89,11 @@ export class Seq<T> implements Iterable<T> {
     }
   }
 
-  toArray(): T[] {
+  toMutableArray(): T[] {
     return [...this];
   }
 
-  toReadonlyArray(): readonly T[] {
+  toArray(): readonly T[] {
     return [...this];
   }
 }

--- a/packages/leseq/tests/operators.test.ts
+++ b/packages/leseq/tests/operators.test.ts
@@ -1,5 +1,14 @@
 import { concat, concatValue, skip, skipWhile, filter, flatten, from, map, orderBy, take, takeWhile, tap, uniq, groupBy, chunk, scan, union, difference, intersect, reverse } from '../src';
 
+test('sec generates readonly array', () => {
+  const readOnlyOutput = from([1, 2, 3, 4]).toReadonlyArray();
+
+  // @ts-expect-error Property 'push' does not exist on type 'readonly number[]'.
+  readOnlyOutput.push(99);
+
+  expect(readOnlyOutput).toEqual([1, 2, 3, 4, 99]);
+});
+
 test('operator: simple concat', () => {
   const output = from([1, 2, 3, 4, 5])
     .pipe(concat([6, 7]))

--- a/packages/leseq/tests/operators.test.ts
+++ b/packages/leseq/tests/operators.test.ts
@@ -1,7 +1,7 @@
 import { concat, concatValue, skip, skipWhile, filter, flatten, from, map, orderBy, take, takeWhile, tap, uniq, groupBy, chunk, scan, union, difference, intersect, reverse } from '../src';
 
 test('sec generates readonly array', () => {
-  const readOnlyOutput = from([1, 2, 3, 4]).toReadonlyArray();
+  const readOnlyOutput = from([1, 2, 3, 4]).toArray();
 
   // @ts-expect-error Property 'push' does not exist on type 'readonly number[]'.
   readOnlyOutput.push(99);
@@ -107,6 +107,17 @@ test('operator: map index', () => {
     .toArray();
   expect(output).toEqual([1, 4, 9]);
   expect(indexes).toEqual([0, 1, 2]);
+});
+
+test('operator: orderBy is not mutate operation', () => {
+  const source = [6, 3, 2, 1, 4, 5];
+  const sourceCopy = source.slice();
+
+  const output = from(source)
+    .pipe(orderBy(i => i))
+    .toArray();
+  expect(output).toEqual([1, 2, 3, 4, 5, 6]);
+  expect(source).toEqual(sourceCopy);
 });
 
 test('operator: orderBy asc', () => {


### PR DESCRIPTION
Hello,

This is a suggestion to support `ReadonlyArray<T>`.
In my opinion, ReadonlyArray is always a preferable choice than mutable one. (So they should be `toMutableArray()` and `toArray()` though, I hesitate to break backward compatibility)

Also, I think some operators are able to support that interface i.e. the result of groupBy.
I would commit for some enhancement if you feel positive against that.

Thanks!
