### PR TITLE
Suggestions to make it easier to exclude null and undefined

### DIFF
--- a/packages/leseq/src/operators/async/filterNotNullAsync.ts
+++ b/packages/leseq/src/operators/async/filterNotNullAsync.ts
@@ -1,0 +1,24 @@
+import {AsyncGen, AsyncOperator, AsyncSeq} from "../../asyncSeq";
+
+/**
+ * Returns a sequence that excludes null and undefined from the current sequence.
+ *
+ * ```typescript
+ * const result = await fromAsAsync([1, 2, null, undefined, 5]).pipe(
+ *   filterNotNull()
+ * ).toArrayAsync();
+ * //result: [1,2,5]
+ * ```
+ *
+ * @returns Operator function.
+ * @typeParam T Source element type.
+ * @category Operators
+ */
+export const filterNotNullAsync = <T>(): AsyncOperator<T, NonNullable<T>> =>
+  async function* filterNotNullAsync(source: AsyncSeq<T>): AsyncGen<NonNullable<T>> {
+    for await (const i of source) {
+      if (i !== null && i !== undefined) {
+        yield i!!;
+      }
+    }
+  };

--- a/packages/leseq/src/operators/async/index.ts
+++ b/packages/leseq/src/operators/async/index.ts
@@ -1,4 +1,5 @@
 export { mapAsync } from './mapAsync';
+export { mapNotNullAsync } from './mapNotNullAsync';
 export { chunkAsync } from './chunkAsync';
 export { scanAsync } from './scanAsync';
 export { orderByAsync } from './orderByAsync';
@@ -8,6 +9,7 @@ export { uniqAsync } from './uniqAsync';
 export { concatAsync } from './concatAsync';
 export { concatValueAsync } from './concatValueAsync';
 export { filterAsync } from './filterAsync';
+export { filterNotNullAsync } from './filterNotNullAsync';
 export { flattenAsync } from './flattenAsync';
 export { takeAsync } from './takeAsync';
 export { takeWhileAsync } from './takeWhileAsync';

--- a/packages/leseq/src/operators/async/mapNotNullAsync.ts
+++ b/packages/leseq/src/operators/async/mapNotNullAsync.ts
@@ -1,0 +1,31 @@
+import {AsyncGen, AsyncOperator, AsyncSeq} from "../../asyncSeq";
+
+/**
+ * Returns the sequence in which each element has been transformed by the specified transformation function.
+ * However, null or undefined elements are excluded from the sequence.
+ *
+ * ```typescript
+ * const result = await fromAsAsync([1, 2, null, 4, undefined]).pipe(
+ *   mapNotNull(i => i?.toString())
+ * ).toArrayAsync();
+ * //result: ["1", "2", "4"]
+ * ```
+ *
+ * @param func Transform function.
+ * @returns Operator function.
+ * @typeParam T Source element type.
+ * @typeParam TResult Transformed element type.
+ * @category Operators
+ */
+export const mapNotNullAsync = <T, TResult>(func: (arg: T, index: number) => Promise<TResult>): AsyncOperator<T, NonNullable<TResult>> =>
+  async function* mapNotNullAsync(source: AsyncSeq<T>): AsyncGen<NonNullable<TResult>> {
+    let count = 0;
+    for await (const i of source) {
+      const result = await func(i, count);
+      if (result !== null && result !== undefined) {
+        yield result!!;
+      }
+
+      count++;
+    }
+  };

--- a/packages/leseq/src/operators/filterNotNull.ts
+++ b/packages/leseq/src/operators/filterNotNull.ts
@@ -1,0 +1,22 @@
+import { Gen, Operator, Seq } from '../seq';
+
+/**
+ * Returns a sequence that excludes null and undefined from the current sequence.
+ *
+ * ```typescript
+ * const result = from([1, 2, null, undefined, 5]).pipe(filterNotNull()).toArray();
+ * //result: [1,2,5]
+ * ```
+ *
+ * @returns Operator function.
+ * @typeParam T Source element type.
+ * @category Operators
+ */
+export const filterNotNull = <T>(): Operator<T, NonNullable<T>> =>
+  function* filterNotNull(source: Seq<T>): Gen<NonNullable<T>> {
+    for (const i of source) {
+      if (i !== null && i !== undefined) {
+        yield i!!;
+      }
+    }
+  };

--- a/packages/leseq/src/operators/index.ts
+++ b/packages/leseq/src/operators/index.ts
@@ -1,4 +1,5 @@
 export { map } from './map';
+export { mapNotNull } from './mapNotNull';
 export { chunk } from './chunk';
 export { scan } from './scan';
 export { orderBy } from './orderBy';
@@ -8,6 +9,7 @@ export { uniq } from './uniq';
 export { concat } from './concat';
 export { concatValue } from './concatValue';
 export { filter } from './filter';
+export { filterNotNull } from './filterNotNull';
 export { flatten } from './flatten';
 export { take } from './take';
 export { takeWhile } from './takeWhile';

--- a/packages/leseq/src/operators/mapNotNull.ts
+++ b/packages/leseq/src/operators/mapNotNull.ts
@@ -1,0 +1,29 @@
+import { Gen, Operator, Seq } from '../seq';
+
+/**
+ * Returns the sequence in which each element has been transformed by the specified transformation function.
+ * However, null or undefined elements are excluded from the sequence.
+ *
+ * ```typescript
+ * const result = from([1, 2, null, 4, undefined]).pipe(mapNotNull(i => i?.toString())).toArray();
+ * //result: ["1", "2", "4"]
+ * ```
+ *
+ * @param func Transform function.
+ * @returns Operator function.
+ * @typeParam T Source element type.
+ * @typeParam TResult Transformed element type.
+ * @category Operators
+ */
+export const mapNotNull = <T, TResult>(func: (arg: T, index: number) => TResult): Operator<T, NonNullable<TResult>> =>
+  function* mapNotNull(source: Seq<T>): Gen<NonNullable<TResult>> {
+    let count = 0;
+    for (const i of source) {
+      const result = func(i, count);
+      if (result !== null && result !== undefined) {
+        yield result!!;
+      }
+
+      count++;
+    }
+  };

--- a/packages/leseq/tests/async-operators.test.ts
+++ b/packages/leseq/tests/async-operators.test.ts
@@ -1,4 +1,27 @@
-import { concat, concatValue, skip, skipWhile, filter, flatten, from, map, orderBy, take, takeWhile, tap, uniq, groupBy, chunk, scan, union, difference, intersect, reverse, concatAsync, fromAsAsync, tapAsync, concatValueAsync, skipAsync, skipWhileAsync, filterAsync, flattenAsync, mapAsync, orderByAsync, takeAsync, takeWhileAsync, uniqAsync, chunkAsync, scanAsync, groupByAsync, unionAsync, differenceAsync, intersectAsync, reverseAsync } from '../src';
+import {
+  concatAsync,
+  fromAsAsync,
+  tapAsync,
+  concatValueAsync,
+  skipAsync,
+  skipWhileAsync,
+  filterAsync,
+  filterNotNullAsync,
+  flattenAsync,
+  mapAsync,
+  mapNotNullAsync,
+  orderByAsync,
+  takeAsync,
+  takeWhileAsync,
+  uniqAsync,
+  chunkAsync,
+  scanAsync,
+  groupByAsync,
+  unionAsync,
+  differenceAsync,
+  intersectAsync,
+  reverseAsync
+} from '../src';
 import { abortableSleep } from './testUtil';
 
 test('operator: simple concatAsync', async () => {
@@ -58,6 +81,13 @@ test('operator: filterAsync index', async () => {
   expect(indexes).toEqual([0, 1, 2, 3, 4, 5]);
 });
 
+test('operator: simple filterNotNullAsync', async () => {
+  const output = await fromAsAsync([2, 4, null, 5, null, undefined, 6, 7, 8])
+    .pipe(filterNotNullAsync())
+    .toArrayAsync();
+  expect(output).toEqual([2, 4, 5, 6, 7, 8]);
+});
+
 test('operator: simple flattenAsync', async () => {
   const output = await fromAsAsync([
     [1, 2],
@@ -108,6 +138,28 @@ test('operator: mapAsync index', async () => {
     .toArrayAsync();
   expect(output).toEqual([1, 4, 9]);
   expect(indexes).toEqual([0, 1, 2]);
+});
+
+test('operator: simple mapNotNullAsync', async () => {
+  const output = await fromAsAsync([1, 2, null, 3, null, null, 4, undefined, 5])
+    .pipe(mapNotNullAsync(async i => i?.toString()))
+    .toArrayAsync();
+  expect(output).toEqual(["1", "2", "3", "4", "5"]);
+});
+
+test('operator: mapNotNullAsync index', async () => {
+  const indexes: number[] = [];
+  const output = await fromAsAsync([1, 2, null, 3, null, null, 4, undefined, 5])
+    .pipe(
+      mapNotNullAsync(async (i, index) => {
+        await abortableSleep(20);
+        indexes.push(index);
+        return i?.toString();
+      })
+    )
+    .toArrayAsync();
+  expect(output).toEqual(["1", "2", "3", "4", "5"]);
+  expect(indexes).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
 });
 
 test('operator: orderByAsync asc', async () => {

--- a/packages/leseq/tests/operators.test.ts
+++ b/packages/leseq/tests/operators.test.ts
@@ -1,4 +1,27 @@
-import { concat, concatValue, skip, skipWhile, filter, flatten, from, map, orderBy, take, takeWhile, tap, uniq, groupBy, chunk, scan, union, difference, intersect, reverse } from '../src';
+import {
+  concat,
+  concatValue,
+  skip,
+  skipWhile,
+  filter,
+  filterNotNull,
+  flatten,
+  from,
+  map,
+  mapNotNull,
+  orderBy,
+  take,
+  takeWhile,
+  tap,
+  uniq,
+  groupBy,
+  chunk,
+  scan,
+  union,
+  difference,
+  intersect,
+  reverse
+} from '../src';
 
 test('operator: simple concat', () => {
   const output = from([1, 2, 3, 4, 5])
@@ -50,6 +73,13 @@ test('operator: filter index', () => {
   expect(indexes).toEqual([0, 1, 2, 3, 4, 5]);
 });
 
+test('operator: simple filterNotNull', () => {
+  const output = from([2, 4, null, 5, null, undefined, 6, 7, 8])
+    .pipe(filterNotNull())
+    .toArray();
+  expect(output).toEqual([2, 4, 5, 6, 7, 8]);
+});
+
 test('operator: simple flatten', () => {
   const output = from([
     [1, 2],
@@ -98,6 +128,27 @@ test('operator: map index', () => {
     .toArray();
   expect(output).toEqual([1, 4, 9]);
   expect(indexes).toEqual([0, 1, 2]);
+});
+
+test('operator: simple mapNotNull', () => {
+  const output = from([1, 2, null, 3, null, null, 4, undefined, 5])
+    .pipe(mapNotNull(i => i?.toString()))
+    .toArray();
+  expect(output).toEqual(["1", "2", "3", "4", "5"]);
+});
+
+test('operator: mapNotNull index', () => {
+  const indexes: number[] = [];
+  const output = from([1, 2, null, 3, null, null, 4, undefined, 5])
+    .pipe(
+      mapNotNull((i, index) => {
+        indexes.push(index);
+        return i?.toString();
+      })
+    )
+    .toArray();
+  expect(output).toEqual(["1", "2", "3", "4", "5"]);
+  expect(indexes).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
 });
 
 test('operator: orderBy asc', () => {


### PR DESCRIPTION
Hello.

I would like to suggest additional operators that will help exclude null and undefined from the sequence.

I think you'll need ritual code like `filter(i => i! == null && i! == undefined)` or `map(i => i !!)` to exclude null and undefined from the sequence. 
I found a hint from Kotlin to solve this problem and used it as a reference.
- [filterNotNull](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/filter-not-null.html)
- [mapNotNull](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/map-not-null.html)

I hope this proposal is meaningful to the project.

Thank you for reading.

PS:
I wrote the composition using Google Translate. Please forgive me for the dull sentences ...